### PR TITLE
Added some other default host lists

### DIFF
--- a/AdAway/src/org/adaway/provider/AdAwayDatabase.java
+++ b/AdAway/src/org/adaway/provider/AdAwayDatabase.java
@@ -95,6 +95,21 @@ public class AdAwayDatabase extends SQLiteOpenHelper {
 
         // http://www.ismeh.com/HOSTS
         insertHostsSource(insertStmt, "http://www.ismeh.com/HOSTS");
+
+	// https://secure.fanboy.co.nz/fanboy-adblock.txt
+	insertHostsSource(insertStmt, "https://secure.fanboy.co.nz/fanboy-adblock.txt");
+
+	// https://easylist-downloads.adblockplus.org/easylist.txt
+	insertHostsSource(insertStmt, "https://easylist-downloads.adblockplus.org/easylist.txt");
+
+	// https://easylist-downloads.adblockplus.org/rolist+easylist.txt
+	insertHostsSource(insertStmt, "https://easylist-downloads.adblockplus.org/rolist+easylist.txt");
+
+	// https://popblock.googlecode.com/hg/popup-block.txt
+	insertHostsSource(insertStmt, "https://popblock.googlecode.com/hg/popup-block.txt");
+
+	// https://secure.fanboy.co.nz/fanboy-addon.txt
+	insertHostsSource(insertStmt, "https://secure.fanboy.co.nz/fanboy-addon.txt");
     }
 
     @Override


### PR DESCRIPTION
I use this lists in my browser everyday.
I think that this app has become an general adblocker for an Android phone, and it musn't be focused only on games ads.

The default lists fom AdBlockPlus extension for Firefox are on line 99-103.
Lines 105-106 are a combination between easylist and Romanian adblock list.
Lines 111-112 are for site annoyances like Facebook like/share button from other sites.
If you merge this, I suggest adding in the default list only block 99-103.

Also, if this gets in PlayStore i would really really appreciate if you say this was my (bad :P) idea.

Thank you.
