### PR TITLE
Add systemless support for MagiskSU

### DIFF
--- a/AdAway/src/main/java/org/adaway/ui/PrefsActivity.java
+++ b/AdAway/src/main/java/org/adaway/ui/PrefsActivity.java
@@ -175,8 +175,6 @@ public class PrefsActivity extends SherlockPreferenceActivity {
 
         // Find systemless mode preferences
         mSystemless = (CheckBoxPreference) getPreferenceScreen().findPreference(getString(R.string.pref_enable_systemless_key));
-        // Check preference if systemless mode is enabled
-        new SystemlessCheckTask().execute();
 
         // find custom target edit
         mCustomTarget = (EditTextPreference) getPreferenceScreen().findPreference(
@@ -224,6 +222,13 @@ public class PrefsActivity extends SherlockPreferenceActivity {
             mWebserverOnBoot.setSummary(R.string.pref_webserver_on_boot_summary);
         }
 
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        // Check preference if systemless mode is enabled
+        new SystemlessCheckTask().execute();
     }
 
     /**

--- a/AdAway/src/main/java/org/adaway/util/SystemlessUtils.java
+++ b/AdAway/src/main/java/org/adaway/util/SystemlessUtils.java
@@ -1,6 +1,7 @@
 package org.adaway.util;
 
 import org.adaway.util.systemless.AbstractSystemlessMode;
+import org.adaway.util.systemless.MagiskSuSystemlessMode;
 import org.adaway.util.systemless.NotSupportedSystemlessMode;
 import org.adaway.util.systemless.SuperSuSystemlessMode;
 import org.adaway.util.systemless.SuperUserSystemlessMode;
@@ -36,20 +37,16 @@ public class SystemlessUtils {
         try {
             // Start shell
             shell = Shell.startShell();
-            Toolbox toolbox = new Toolbox(shell);
-            // Check if ChainFire's SuperSU systemless root is installed
-            if (toolbox.fileExists("/su/bin/su")) {
+            // Check each supported su implementations
+            if (SystemlessUtils.checkChainFireSuperSu(shell)) {
                 SystemlessUtils.systemlessMode = new SuperSuSystemlessMode();
+            } else if (SystemlessUtils.checkPhhSuperUserSuBind(shell)) {
+                SystemlessUtils.systemlessMode = new SuperUserSystemlessMode();
+            } else if (SystemlessUtils.checkMagiskSu(shell)) {
+                SystemlessUtils.systemlessMode = new MagiskSuSystemlessMode();
             } else {
-                // Check if phh's SuperUser su bind is installed
-                SimpleCommand command = new SimpleCommand("su -v | grep subind");
-                shell.add(command).waitForFinish();
-                if (command.getExitCode() == 0) {
-                    SystemlessUtils.systemlessMode = new SuperUserSystemlessMode();
-                } else {
-                    // Otherwise not supported systemless mode
-                    SystemlessUtils.systemlessMode = new NotSupportedSystemlessMode();
-                }
+                // Otherwise not supported systemless mode
+                SystemlessUtils.systemlessMode = new NotSupportedSystemlessMode();
             }
         } catch (Exception exception) {
             Log.e(Constants.TAG, "Error while getting systemless mode.", exception);
@@ -66,5 +63,46 @@ public class SystemlessUtils {
         }
         // Return found systemless mode
         return SystemlessUtils.systemlessMode;
+    }
+
+    /**
+     * Check installation of ChainFire's SuperSU systemless root.
+     *
+     * @param shell The current shell.
+     * @return <code>true</code> if the ChainFire's SuperSU systemless root is installed, <code>false</code> otherwise.
+     * @throws Exception if the installation could not be checked.
+     */
+    private static boolean checkChainFireSuperSu(Shell shell) throws Exception {
+        // Check if a su binary is present in su partition
+        Toolbox toolbox = new Toolbox(shell);
+        return toolbox.fileExists("/su/bin/su");
+    }
+
+    /**
+     * Check installation of SuperUser su bind.
+     *
+     * @param shell The current shell.
+     * @return <code>true</code> if the SuperUser su bind is install, <code>false</code> otherwise.
+     * @throws Exception if the installation could not be checked.
+     */
+    private static boolean checkPhhSuperUserSuBind(Shell shell) throws Exception {
+        // Check if phh's SuperUser su bind is installed
+        SimpleCommand command = new SimpleCommand("su -v | grep subind");
+        shell.add(command).waitForFinish();
+        return command.getExitCode() == 0;
+    }
+
+    /**
+     * Check installation of MagiskSU.
+     *
+     * @param shell The current shell.
+     * @return <code>true</code> if the MagiskSU is installed, <code>false</code> otherwise.
+     * @throws Exception if the installation could not be checked.
+     */
+    private static boolean checkMagiskSu(Shell shell) throws Exception {
+        // Check if MagiskSU is installed
+        SimpleCommand command = new SimpleCommand("su -v | grep MAGISKSU");
+        shell.add(command).waitForFinish();
+        return command.getExitCode() == 0;
     }
 }

--- a/AdAway/src/main/java/org/adaway/util/systemless/MagiskSuSystemlessMode.java
+++ b/AdAway/src/main/java/org/adaway/util/systemless/MagiskSuSystemlessMode.java
@@ -1,0 +1,86 @@
+package org.adaway.util.systemless;
+
+import android.content.Context;
+
+import org.adaway.util.Constants;
+import org.adaway.util.Log;
+import org.sufficientlysecure.rootcommands.Shell;
+import org.sufficientlysecure.rootcommands.command.SimpleCommand;
+
+import java.io.IOException;
+
+/**
+ * This class provides methods to launch Magisk settings in order to enable systemless mode.
+ *
+ * @author Bruce BUJON (bruce.bujon(at)gmail(dot)com)
+ */
+public class MagiskSuSystemlessMode extends AbstractSystemlessMode {
+    /**
+     * The Magisk package name.
+     */
+    private static final String MAGISK_PACKAGE_NAME = "com.topjohnwu.magisk";
+    /**
+     * The Magisk settings class name.
+     */
+    private static final String MAGISK_SETTINGS_CLASS_NAME = "SettingsActivity";
+
+    @Override
+    boolean isEnabled(Context context, Shell shell) throws Exception {
+        // Look for mount point of system hosts file
+        SimpleCommand command = new SimpleCommand("mount | grep " + Constants.ANDROID_SYSTEM_ETC_HOSTS);
+        shell.add(command).waitForFinish();
+        return command.getExitCode() == 0;
+    }
+
+    @Override
+    public boolean enable(Context context) {
+        // Start Magisk settings
+        this.startMagiskSettings();
+        // Check if enabled
+        return this.isEnabled(context);
+
+    }
+
+    @Override
+    public boolean disable(Context context) {
+        // Start Magisk settings
+        this.startMagiskSettings();
+        // Check if disable
+        return !this.isEnabled(context);
+    }
+
+    /**
+     * Start Magisk settings.
+     */
+    private void startMagiskSettings() {
+        /*
+         * The following method is not allowed as the activity is not exported.
+         *
+        // Start activity to display Magisk settings
+        Intent intent = new Intent();
+        intent.setClassName(MagiskSuSystemlessMode.MAGISK_PACKAGE_NAME, MagiskSuSystemlessMode.MAGISK_SETTINGS_CLASS_NAME);
+        context.startActivity(intent);
+        *
+        * So we use am start as root to start activity.
+        */
+        // Declare root shell
+        Shell shell = null;
+        try {
+            // Start root shell
+            shell = Shell.startRootShell();
+            SimpleCommand command = new SimpleCommand("am start -n " + MagiskSuSystemlessMode.MAGISK_PACKAGE_NAME + "/." + MagiskSuSystemlessMode.MAGISK_SETTINGS_CLASS_NAME);
+            shell.add(command);
+        } catch (Exception exception) {
+            Log.e(Constants.TAG, "Error while opening Magisk settings activity.", exception);
+        } finally {
+            // Close root shell
+            if (shell != null) {
+                try {
+                    shell.close();
+                } catch (IOException exception) {
+                    Log.d(Constants.TAG, "Error while closing root shell.", exception);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
MagiskSU will now be detected.
If installed, the systemless settings will be enabled and checked accoring the current systemless status.
Pressing the AdAways settings will open the Magisk settings (with a hack, check at the source for the whole details) and coming back from the Magisk settings will update the AdAway systemless settings state. No
reboot is needed.