### PR TITLE
Fix root request not working with magisk 15.x

### DIFF
--- a/AdAway/src/main/java/org/adaway/ui/BaseActivity.java
+++ b/AdAway/src/main/java/org/adaway/ui/BaseActivity.java
@@ -45,7 +45,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.LocalBroadcastManager;
 import android.view.View;
-import java.io.IOException;
 
 public class BaseActivity extends SherlockFragmentActivity {
 
@@ -111,18 +110,6 @@ public class BaseActivity extends SherlockFragmentActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.base_activity);
-
-        // The RootCommands library is not well supported by Magisk 15.x
-        // Magisk doesn't recognize the root request and doesn't show it to the user.
-        // This leads to an application freeze at startup.
-        // To solve this problem, we use the following line to force a root request that
-        // is recognized by magisk and shown to the user. Once the user has granted this
-        // request, the rest of the RootCommands library will work.
-        try {
-            Runtime.getRuntime().exec("su");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
 
         mActivity = this;
 

--- a/AdAway/src/main/java/org/adaway/ui/BaseActivity.java
+++ b/AdAway/src/main/java/org/adaway/ui/BaseActivity.java
@@ -45,6 +45,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.LocalBroadcastManager;
 import android.view.View;
+import java.io.IOException;
 
 public class BaseActivity extends SherlockFragmentActivity {
 
@@ -110,6 +111,18 @@ public class BaseActivity extends SherlockFragmentActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.base_activity);
+
+        // The RootCommands library is not well supported by Magisk 15.x
+        // Magisk doesn't recognize the root request and doesn't show it to the user.
+        // This leads to an application freeze at startup.
+        // To solve this problem, we use the following line to force a root request that
+        // is recognized by magisk and shown to the user. Once the user has granted this
+        // request, the rest of the RootCommands library will work.
+        try {
+            Runtime.getRuntime().exec("su");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
 
         mActivity = this;
 

--- a/libraries/RootCommands/src/main/java/org/sufficientlysecure/rootcommands/Shell.java
+++ b/libraries/RootCommands/src/main/java/org/sufficientlysecure/rootcommands/Shell.java
@@ -57,7 +57,9 @@ public class Shell implements Closeable {
         if (customEnv == null) {
             customEnv = new ArrayList<>();
         }
-        customEnv.add("LD_LIBRARY_PATH=" + LD_LIBRARY_PATH);
+        if(LD_LIBRARY_PATH != null){
+            customEnv.add("LD_LIBRARY_PATH=" + LD_LIBRARY_PATH);
+        }
 
         return new Shell(Utils.getSuPath(), customEnv, baseDirectory);
     }


### PR DESCRIPTION
Magisk versions greater than 15 don't recognize RootCommands library's root requests.
To solve this, we force a request at startup with `Runtime` that will allow the
user to grant root access to the app. Once root is granted, all the
other root functionalities will work.