### PR TITLE
Fix root not working with magisk 15.x

### DIFF
--- a/libraries/RootCommands/src/main/java/org/sufficientlysecure/rootcommands/Shell.java
+++ b/libraries/RootCommands/src/main/java/org/sufficientlysecure/rootcommands/Shell.java
@@ -57,7 +57,9 @@ public class Shell implements Closeable {
         if (customEnv == null) {
             customEnv = new ArrayList<>();
         }
-        customEnv.add("LD_LIBRARY_PATH=" + LD_LIBRARY_PATH);
+        if(LD_LIBRARY_PATH != null){
+            customEnv.add("LD_LIBRARY_PATH=" + LD_LIBRARY_PATH);
+        }
 
         return new Shell(Utils.getSuPath(), customEnv, baseDirectory);
     }


### PR DESCRIPTION
The shared librares path `LD_LIBRARY_PATH` is null on some device and
this made the request not to be recognized by newer versions of magisk.