### PR TITLE
Switch to material variants for CAB icons

### DIFF
--- a/app/src/main/res/drawable/ic_menu_delete.xml
+++ b/app/src/main/res/drawable/ic_menu_delete.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?android:attr/textColorPrimary">
+    <path
+        android:pathData="M6 19c0 1.1 0.9 2 2 2h8c1.1 0 2 -0.9 2 -2V9c0 -1.1 -0.9 -2 -2 -2H8c-1.1 0 -2 0.9 -2 2v10zm3.17 -7.83c0.39 -0.39 1.02 -0.39 1.41 0L12 12.59l1.42 -1.42c0.39 -0.39 1.02 -0.39 1.41 0 0.39 0.39 0.39 1.02 0 1.41L13.41 14l1.42 1.42c0.39 0.39 0.39 1.02 0 1.41 -0.39 0.39 -1.02 0.39 -1.41 0L12 15.41l-1.42 1.42c-0.39 0.39 -1.02 0.39 -1.41 0 -0.39 -0.39 -0.39 -1.02 0 -1.41L10.59 14l-1.42 -1.42c-0.39 -0.38 -0.39 -1.02 0 -1.41zM15.5 4l-0.71 -0.71c-0.18 -0.18 -0.44 -0.29 -0.7 -0.29H9.91c-0.26 0 -0.52 0.11 -0.7 0.29L8.5 4H6c-0.55 0 -1 0.45 -1 1s0.45 1 1 1h12c0.55 0 1 -0.45 1 -1s-0.45 -1 -1 -1h-2.5z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/app/src/main/res/drawable/ic_menu_edit.xml
+++ b/app/src/main/res/drawable/ic_menu_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?android:attr/textColorPrimary">
+    <path
+        android:pathData="M3 17.46v3.04c0 0.28 0.22 0.5 0.5 0.5h3.04c0.13 0 0.26 -0.05 0.35 -0.15L17.81 9.94l-3.75 -3.75L3.15 17.1c-0.1 0.1 -0.15 0.22 -0.15 0.36zM20.71 7.04c0.39 -0.39 0.39 -1.02 0 -1.41l-2.34 -2.34c-0.39 -0.39 -1.02 -0.39 -1.41 0l-1.83 1.83 3.75 3.75 1.83 -1.83z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/app/src/main/res/menu/checkbox_list_context.xml
+++ b/app/src/main/res/menu/checkbox_list_context.xml
@@ -3,11 +3,11 @@
 
     <item
         android:id="@+id/checkbox_list_context_edit"
-        android:icon="@android:drawable/ic_menu_edit"
+        android:icon="@drawable/ic_menu_edit"
         android:title="@string/checkbox_list_context_edit" />
     <item
         android:id="@+id/checkbox_list_context_delete"
-        android:icon="@android:drawable/ic_menu_delete"
+        android:icon="@drawable/ic_menu_delete"
         android:title="@string/checkbox_list_context_delete" />
 
 </menu>


### PR DESCRIPTION
It's generally a bad practice to rely on holo era framework
icons and with the advent of vector drawables even APK size
does not form a compelling argument for this. Also they're just
downright ugly.

[Screenshot](https://i.imgur.com/e1Ky4go.png)