### PR TITLE
Use colorBackground for navigation drawer bg

### DIFF
--- a/app/src/main/res/layout/base_activity_drawer.xml
+++ b/app/src/main/res/layout/base_activity_drawer.xml
@@ -17,7 +17,7 @@
         android:layout_width="240dp"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:background="?android:windowBackground">
+        android:background="?android:attr/colorBackground">
 
         <ListView
             android:id="@+id/left_drawer_list"


### PR DESCRIPTION
This keeps things working as-is for the app while allowing
Substratum themes to make changes in a minimally invasive
way.