### PR TITLE
Update Shell.java

### DIFF
--- a/libraries/RootCommands/src/main/java/org/sufficientlysecure/rootcommands/Shell.java
+++ b/libraries/RootCommands/src/main/java/org/sufficientlysecure/rootcommands/Shell.java
@@ -51,7 +51,7 @@ public class Shell implements Closeable {
             throws IOException {
         Log.d(RootCommands.TAG, "Starting Root Shell!");
 
-        return new Shell(Utils.getSuPath(), customEnv, baseDirectory);
+        return new Shell("su", customEnv, baseDirectory);
     }
 
     /**


### PR DESCRIPTION
When I changed the rooting method to Magisk, the following error began to occur:

Failed to update hosts file.
org.adaway.model.hostsinstall.HostsInstallException: Root access denied
	at org.adaway.model.hostsinstall.HostsInstallModel.applyHostsFile(HostsInstallModel.java:455)
	at org.adaway.ui.home.HostsInstallViewModel.lambda$update$2$HostsInstallViewModel(HostsInstallViewModel.java:124)
	at org.adaway.ui.home.-$$Lambda$HostsInstallViewModel$hr_O0jGNR8I8qQyGthIQYups81s.run(lambda)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
	at java.lang.Thread.run(Thread.java:818)
Caused by: org.sufficientlysecure.rootcommands.util.RootAccessDeniedException: stdout line is null! Access was denied or this executeable is not a shell!
	at org.sufficientlysecure.rootcommands.Shell.<init>(Shell.java:134)
	at org.sufficientlysecure.rootcommands.Shell.startRootShell(Shell.java:54)
	at org.sufficientlysecure.rootcommands.Shell.startRootShell(Shell.java:63)
	at org.adaway.model.hostsinstall.HostsInstallModel.applyHostsFile(HostsInstallModel.java:439)
	... 5 more

UI to accept or deny isn't shown. App isn't listed in Magisk Superuser like it newer requested root.
This patch fixes the problem. Even the reference implementation of libsupersu by chainfire (https://github.com/Chainfire/libsuperuser/blob/master/libsuperuser/src/eu/chainfire/libsuperuser/Shell.java) does not iterate over possible su binary locations like this lib does. It's a bit strange, but works for me. This can also fix https://github.com/AdAway/AdAway/issues/1140
P.S. Stock Android 5.1.1 with Magisk 20.0 and AdAway 4.2.9