### PR TITLE
New feature: Show latest hosts file diff

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     implementation 'com.annimon:stream:1.2.1'
     implementation 'com.google.android:flexbox:1.1.0'
     implementation 'com.squareup.okhttp3:okhttp:3.12.0'
+    implementation "io.github.java-diff-utils:java-diff-utils:4.5"
     implementation 'net.sf.trove4j:trove4j:3.0.3'
     implementation 'org.sufficientlysecure:html-textview:3.4'
     if (keyStoreDefined) {

--- a/app/src/main/java/org/adaway/ui/hostscontent/HostsContentFragment.java
+++ b/app/src/main/java/org/adaway/ui/hostscontent/HostsContentFragment.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,6 +17,7 @@ import android.widget.TextView;
 
 import org.adaway.R;
 import org.adaway.helper.OpenHelper;
+import org.adaway.ui.hostsdiff.HostsDiffFragment;
 import org.adaway.util.Constants;
 import org.adaway.util.Log;
 
@@ -51,14 +53,32 @@ public class HostsContentFragment extends Fragment {
         // Load hosts file content
         new HostsContentLoader(hostsContextTextView::setText).execute();
         /*
-         * Configure menu button.
+         * Configure menu buttons.
          */
         // Get open file button
         Button openFileButton = view.findViewById(R.id.hosts_open_file);
         // Bind on click listener
         openFileButton.setOnClickListener(button -> OpenHelper.openHostsFile(activity));
+        // Show diff button
+        Button showDiffButton = view.findViewById(R.id.hosts_diff);
+        File backupFile = getContext().getFileStreamPath(Constants.HOSTS_BACKUP_FILENAME);
+        showDiffButton.setEnabled(backupFile != null && backupFile.exists());
+        showDiffButton.setOnClickListener(button -> showHostsDiff());
         // Return created view
         return view;
+    }
+
+    /**
+     * Show the hosts diff fragment.
+     */
+    private void showHostsDiff() {
+        Fragment fragment = new HostsDiffFragment();
+        FragmentManager fragmentManager = getFragmentManager();
+        // Insert the fragment by replacing any existing fragment
+        fragmentManager.beginTransaction()
+                .replace(R.id.content_frame, fragment)
+                .addToBackStack(null)
+                .commit();
     }
 
     /**

--- a/app/src/main/java/org/adaway/ui/hostsdiff/CallbackInterface.java
+++ b/app/src/main/java/org/adaway/ui/hostsdiff/CallbackInterface.java
@@ -1,0 +1,12 @@
+package org.adaway.ui.hostsdiff;
+
+import androidx.annotation.NonNull;
+
+interface CallbackInterface {
+
+    void showProgressBar(int progress, int max);
+
+    void hideProgressBar();
+
+    void setResult(@NonNull String string);
+}

--- a/app/src/main/java/org/adaway/ui/hostsdiff/HostsDiffFragment.java
+++ b/app/src/main/java/org/adaway/ui/hostsdiff/HostsDiffFragment.java
@@ -113,7 +113,7 @@ public class HostsDiffFragment extends Fragment implements CallbackInterface {
         /**
          * The maximum number of lines of the result.
          */
-        private static final short MAX_LINES = 50;
+        private static final short MAX_LINES = 100;
 
         /**
          * Line counter to limit the length of the result.
@@ -180,19 +180,28 @@ public class HostsDiffFragment extends Fragment implements CallbackInterface {
         private String generateDiffResult(@NonNull Patch<String> patch) {
             StringWriter stringWriter = new StringWriter();
             PrintWriter writer = new PrintWriter(stringWriter);
+            // show added lines
             for (AbstractDelta<String> delta : patch.getDeltas()) {
-                printLine("Source position: " + delta.getSource().getPosition(), writer);
                 switch (delta.getType()) {
                     case CHANGE:
-                        printLines("-", delta.getSource().getLines(), writer);
+                    case INSERT:
                         printLines("+", delta.getTarget().getLines(), writer);
                         break;
+                    case DELETE:
+                    case EQUAL:
+                    default:
+                        // hide unchanged lines, show only differences
+                }
+            }
+            writer.println(); // empty line
+            // show removed lines
+            for (AbstractDelta<String> delta : patch.getDeltas()) {
+                switch (delta.getType()) {
+                    case CHANGE:
                     case DELETE:
                         printLines("-", delta.getSource().getLines(), writer);
                         break;
                     case INSERT:
-                        printLines("+", delta.getTarget().getLines(), writer);
-                        break;
                     case EQUAL:
                     default:
                         // hide unchanged lines, show only differences
@@ -213,7 +222,10 @@ public class HostsDiffFragment extends Fragment implements CallbackInterface {
          */
         private void printLines(@NonNull String prefix, @NonNull List<String> lines, @NonNull PrintWriter writer) {
             for (String line : lines) {
-                printLine(prefix + line, writer);
+                // hide white space diff
+                if (!line.trim().isEmpty()) {
+                    printLine(prefix + line, writer);
+                }
             }
         }
 

--- a/app/src/main/java/org/adaway/ui/hostsdiff/HostsDiffFragment.java
+++ b/app/src/main/java/org/adaway/ui/hostsdiff/HostsDiffFragment.java
@@ -1,0 +1,254 @@
+package org.adaway.ui.hostsdiff;
+
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.algorithm.DiffAlgorithmListener;
+import com.github.difflib.algorithm.DiffException;
+import com.github.difflib.patch.AbstractDelta;
+import com.github.difflib.patch.Patch;
+
+import org.adaway.R;
+import org.adaway.util.ApplyUtils;
+import org.adaway.util.Constants;
+import org.adaway.util.Log;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.ref.WeakReference;
+import java.util.List;
+
+/**
+ * Shows the hosts diff from the latest update.
+ */
+public class HostsDiffFragment extends Fragment implements CallbackInterface {
+
+    private View view;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        view = inflater.inflate(R.layout.hosts_diff_fragment, container, false);
+        // Generate and show hosts diff
+        try {
+            String androidHostsFilename = ApplyUtils.getAndroidHostsFilename(view.getContext());
+            FileInputStream androidHostsInputStream = new FileInputStream(new File(androidHostsFilename));
+            FileInputStream privateHostsInputStream = view.getContext().openFileInput(Constants.HOSTS_BACKUP_FILENAME);
+            new HostsDiffGenerator(androidHostsInputStream, privateHostsInputStream, this).execute();
+        } catch (FileNotFoundException e) {
+            Log.i(Constants.TAG, "Hosts backup file doesn't exist.", e);
+            setResult("Error: Hosts backup file doesn't exist.");
+        }
+        return view;
+    }
+
+    /**
+     * Show the progress bar.
+     */
+    public void showProgressBar(int progress, int max) {
+        if (view == null) {
+            return;
+        }
+        ProgressBar progressBar = view.findViewById(R.id.diff_progressbar);
+        progressBar.setIndeterminate(false);
+        progressBar.setMax(max);
+        progressBar.setProgress(progress);
+        progressBar.setVisibility(View.VISIBLE);
+    }
+
+    /**
+     * Hide the progress bar.
+     */
+    public void hideProgressBar() {
+        if (view == null) {
+            return;
+        }
+        ProgressBar progressBar = view.findViewById(R.id.diff_progressbar);
+        progressBar.setVisibility(View.GONE);
+    }
+
+    /**
+     * Show the diff result.
+     */
+    public void setResult(@NonNull String string) {
+        if (view == null) {
+            return;
+        }
+        TextView hostsDiffTextView = view.findViewById(R.id.hosts_diff_text);
+        hostsDiffTextView.setText(string);
+    }
+
+    /**
+     * This class is a {@link AsyncTask} to calculate the hosts diff.
+     */
+    private static class HostsDiffGenerator extends AsyncTask<Void, Integer, String> {
+
+        /**
+         * InputStream to read the previous hosts file.
+         */
+        @NonNull
+        private final InputStream oldHostsFileInputStream;
+
+        /**
+         * InputStream to read the current hosts file.
+         */
+        @NonNull
+        private final InputStream newHostsFileInputStream;
+
+        /**
+         * The maximum number of lines of the result.
+         */
+        private static final short MAX_LINES = 50;
+
+        /**
+         * Line counter to limit the length of the result.
+         */
+        private int lineCount = 0;
+
+        /**
+         * The callback to call with the hosts file content.
+         */
+        @NonNull
+        private final WeakReference<CallbackInterface> callback;
+
+        /**
+         * Constructor.
+         *
+         * @param callback The callback to call with the hosts file content.
+         */
+        private HostsDiffGenerator(@NonNull InputStream oldHostsFileInputStream, @NonNull InputStream newHostsFileInputStream, @NonNull CallbackInterface callback) {
+            this.oldHostsFileInputStream = oldHostsFileInputStream;
+            this.newHostsFileInputStream = newHostsFileInputStream;
+            this.callback = new WeakReference<>(callback);
+        }
+
+        @Override
+        protected String doInBackground(Void... params) {
+            try {
+                // Read hosts files
+                List<String> oldHostsLines = ApplyUtils.readTextFile(oldHostsFileInputStream);
+                List<String> newHostsLines = ApplyUtils.readTextFile(newHostsFileInputStream);
+                // Calculate diff
+                DiffAlgorithmListener diffAlgorithmListener = new DiffAlgorithmListener() {
+                    @Override
+                    public void diffStart() {
+                        Log.d(Constants.TAG, "Calculating hosts diff started");
+                    }
+
+                    @Override
+                    public void diffStep(int value, int max) {
+                        Log.d(Constants.TAG, "Calculating hosts diff: Step " + value + "/" + max);
+                        publishProgress(value, max);
+                    }
+
+                    @Override
+                    public void diffEnd() {
+                        Log.d(Constants.TAG, "Calculating hosts diff finished");
+                    }
+                };
+                Patch<String> patch = DiffUtils.diff(oldHostsLines, newHostsLines, diffAlgorithmListener);
+                // Generate diff result String representation
+                return generateDiffResult(patch);
+            } catch (IOException e) {
+                Log.i(Constants.TAG, "Failed to load hosts file content.", e);
+                return "Error: Failed to load hosts file content.";
+            } catch (DiffException e) {
+                Log.i(Constants.TAG, "Error while calculating diff between old and new hosts file.", e);
+                return "Error while calculating diff between old and new hosts file.";
+            }
+        }
+
+        /**
+         * Generate diff result String representation.
+         */
+        @NonNull
+        private String generateDiffResult(@NonNull Patch<String> patch) {
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter writer = new PrintWriter(stringWriter);
+            for (AbstractDelta<String> delta : patch.getDeltas()) {
+                printLine("Source position: " + delta.getSource().getPosition(), writer);
+                switch (delta.getType()) {
+                    case CHANGE:
+                        printLines("-", delta.getSource().getLines(), writer);
+                        printLines("+", delta.getTarget().getLines(), writer);
+                        break;
+                    case DELETE:
+                        printLines("-", delta.getSource().getLines(), writer);
+                        break;
+                    case INSERT:
+                        printLines("+", delta.getTarget().getLines(), writer);
+                        break;
+                    case EQUAL:
+                    default:
+                        // hide unchanged lines, show only differences
+                }
+            }
+            if (lineCount >= MAX_LINES) {
+                writer.println("...");
+            }
+            return stringWriter.toString();
+        }
+
+        /**
+         * Writes lines with prefix to a PrintWriter.
+         *
+         * @param prefix Write prefix in front of every line
+         * @param lines  List of line to write
+         * @param writer PrintWriter to write the output to
+         */
+        private void printLines(@NonNull String prefix, @NonNull List<String> lines, @NonNull PrintWriter writer) {
+            for (String line : lines) {
+                printLine(prefix + line, writer);
+            }
+        }
+
+        /**
+         * Write a single line if the maximum line count is not hit.
+         *
+         * @param line   Line to write
+         * @param writer PrintWriter to write the output to
+         */
+        private void printLine(@NonNull String line, @NonNull PrintWriter writer) {
+            if (lineCount >= MAX_LINES) {
+                return;
+            }
+            writer.println(line);
+            lineCount++;
+        }
+
+        @Override
+        protected void onProgressUpdate (Integer... values) {
+            if (values.length != 2) {
+                return;
+            }
+            CallbackInterface callbackInterface = HostsDiffGenerator.this.callback.get();
+            if (callbackInterface != null) {
+                callbackInterface.showProgressBar(values[0], values[1]);
+            }
+        }
+
+        @Override
+        protected void onPostExecute(String content) {
+            CallbackInterface callbackInterface = this.callback.get();
+            if (callbackInterface != null) {
+                callbackInterface.hideProgressBar();
+                callbackInterface.setResult(content);
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/adaway/ui/hostsdiff/HostsDiffFragment.java
+++ b/app/src/main/java/org/adaway/ui/hostsdiff/HostsDiffFragment.java
@@ -49,7 +49,7 @@ public class HostsDiffFragment extends Fragment implements CallbackInterface {
             String androidHostsFilename = ApplyUtils.getAndroidHostsFilename(view.getContext());
             FileInputStream androidHostsInputStream = new FileInputStream(new File(androidHostsFilename));
             FileInputStream privateHostsInputStream = view.getContext().openFileInput(Constants.HOSTS_BACKUP_FILENAME);
-            new HostsDiffGenerator(androidHostsInputStream, privateHostsInputStream, this).execute();
+            new HostsDiffGenerator(privateHostsInputStream, androidHostsInputStream, this).execute();
         } catch (FileNotFoundException e) {
             Log.i(Constants.TAG, "Hosts backup file doesn't exist.", e);
             setResult("Error: Hosts backup file doesn't exist.");

--- a/app/src/main/java/org/adaway/util/Constants.java
+++ b/app/src/main/java/org/adaway/util/Constants.java
@@ -39,6 +39,7 @@ public class Constants {
 
     public static final String DOWNLOADED_HOSTS_FILENAME = "hosts_downloaded";
     public static final String HOSTS_FILENAME = "hosts";
+    public static final String HOSTS_BACKUP_FILENAME = "hosts_backup";
     public static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
     public static final String FILE_SEPARATOR = System.getProperty("file.separator", "/");
 

--- a/app/src/main/res/layout/hosts_content_fragment.xml
+++ b/app/src/main/res/layout/hosts_content_fragment.xml
@@ -70,6 +70,18 @@
                         android:paddingLeft="8dp"
                         android:paddingRight="8dp"
                         android:text="@string/hosts_open_button" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/hosts_diff"
+                        style="@style/Widget.MaterialComponents.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="8dp"
+                        android:layout_marginRight="8dp"
+                        android:paddingLeft="8dp"
+                        android:paddingRight="8dp"
+                        android:text="@string/hosts_diff_button" />
+
                 </LinearLayout>
 
             </LinearLayout>

--- a/app/src/main/res/layout/hosts_diff_fragment.xml
+++ b/app/src/main/res/layout/hosts_diff_fragment.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/card_spacing">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/hosts_diff_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/card_inner_padding"
+                    android:text="@string/hosts_diff_header"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1" />
+
+                <View
+                    android:id="@+id/separator_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginLeft="@dimen/card_inner_padding"
+                    android:layout_marginRight="@dimen/card_inner_padding"
+                    android:background="@color/card_spacer" />
+
+                <ProgressBar
+                    android:id="@+id/diff_progressbar"
+                    style="@android:style/Widget.Holo.ProgressBar.Horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:indeterminate="true"
+                    android:indeterminateTint="#2324aa"
+                    android:visibility="gone" />
+
+                <TextView
+                    android:id="@+id/hosts_diff_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="monospace"
+                    android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
+                    android:paddingBottom="16dp"
+                    android:text="@string/hosts_diff_content"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -61,7 +61,7 @@
     <string name="hosts_description">Die Hosts-Datei ist eine Systemdatei, die Hostnamen IP-Adressen zuweist. Es ist eine reine Textdatei, deren Konfiguration von AdAway erledigt wird. Hier sind einige ihrer ersten Zeilen:</string>
     <string name="hosts_content">Inhalte der Hosts-Datei laden ...</string>
     <string name="hosts_open_button">Hosts-Datei öffnen</string>
-    <string name="hosts_diff_button">Zeige letzte Änderungen</string>
+    <string name="hosts_diff_button">Letzte Änderungen anzeigen</string>
     <string name="hosts_diff_header">Letzte Änderungen in der Hosts-Datei</string>
     <string name="hosts_diff_content">Lade Hosts-Änderungen…</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -61,6 +61,9 @@
     <string name="hosts_description">Die Hosts-Datei ist eine Systemdatei, die Hostnamen IP-Adressen zuweist. Es ist eine reine Textdatei, deren Konfiguration von AdAway erledigt wird. Hier sind einige ihrer ersten Zeilen:</string>
     <string name="hosts_content">Inhalte der Hosts-Datei laden ...</string>
     <string name="hosts_open_button">Hosts-Datei öffnen</string>
+    <string name="hosts_diff_button">Zeige letzte Änderungen</string>
+    <string name="hosts_diff_header">Letzte Änderungen in der Hosts-Datei</string>
+    <string name="hosts_diff_content">Lade Hosts-Änderungen…</string>
 
     <!--Status Notification-->
     <string name="status_checking">Aktualisierungsprüfung …</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,9 @@
     <string name="hosts_description">The hosts file is a system file that maps hostnames to IP addresses. It is a plain text file which configuration is handled by AdAway. Here are its few first lines:</string>
     <string name="hosts_content">Loading the hosts file content…</string>
     <string name="hosts_open_button">Open the hosts file</string>
+    <string name="hosts_diff_button">Show latest changes</string>
+    <string name="hosts_diff_header">Latest content changes of the hosts file</string>
+    <string name="hosts_diff_content">Loading the hosts changes…</string>
 
     <!--Status Notification-->
     <string name="status_checking">Checking for update…</string>


### PR DESCRIPTION
After a hosts file update I'm interested to see the changes (diff). For this I added a feature that works quite well for me and I'm happy to contribute it to AdAway if you are interested.

Steps to show the hosts diff:

1. Click on the burger button
2. Open hosts file
3. Scroll to the bottom, there is a new button "Show latest changes". Click on it.
4. You can see a diff of the latest hosts changes.

Implementation details:

- The button "Show latest changes" is greyed out if AdAway hasn't been activated and thus hasn't modified the hosts file yet.
- The diff view shows maximum 50 lines.
- Internally, the Android hosts file is copied to a private file `hosts_backup` before the update. It is used to calculate the diff.
- I refactored the classes `HostsInstallModel` and `ApplyUtils` and extracted a method `getAndroidHostsFilename()` to avoid code duplication.
- New dependency to `java-diff-utils` for the diff algorithm.