### PR TITLE
Update short_description.txt

### DIFF
--- a/metadata/de/short_description.txt
+++ b/metadata/de/short_description.txt
@@ -1,1 +1,1 @@
-AdAway ist ein Open-Source-Werbeblocker für Android, der die Hosts-Datei verwendet.
+AdAway ist ein Werbeblocker, der die Hosts-Datei anpasst.


### PR DESCRIPTION
The F-Droid app cuts of the old German text version: "AdAway ist ein Open-Source-Werbeblocker für Android, der die Hosts-Datei verwend" - the string should end with "verwendet." - I shortened the text to fix this. (I used the GitHub website to submit this change. I don't manually named the branch.)