### PR TITLE
fix(webserver): Set max validity time to 398 days

### DIFF
--- a/Resources/certificate/generate.sh
+++ b/Resources/certificate/generate.sh
@@ -6,4 +6,4 @@ if [[ $kernel == MINGW* ]]; then
   export MSYS_NO_PATHCONV=1
 fi
 
-openssl req -x509 -out localhost.crt -keyout localhost.key -newkey rsa:2048 -nodes -sha256 -days 1126 -subj /CN=localhost -extensions EXT -config ssl.conf
+openssl req -x509 -out localhost.crt -keyout localhost.key -newkey rsa:2048 -nodes -sha256 -days 398 -subj /CN=localhost -extensions EXT -config ssl.conf


### PR DESCRIPTION
Fix #2875 (again).

Nowadays, major web browser vendors reduced TLS certificates maximum lifetime to **398 days**.

it cause error like `NET::ERR_CERT_VALIDITY_TOO_LONG` (if chromium).

- Apple: [About upcoming limits on trusted certificates - Apple Support](https://support.apple.com/en-us/HT211025)
- Google: [Certificate Lifetimes](https://chromium.googlesource.com/chromium/src/+/master/net/docs/certificate_lifetimes.md)
- Mozilla: [Reducing TLS Certificate Lifespans to 398 Days - Mozilla Security Blog](https://blog.mozilla.org/security/2020/07/09/reducing-tls-certificate-lifespans-to-398-days/)

