### PR TITLE
Add check for "Always-on VPN" on VpnService intent failure

### DIFF
--- a/app/src/main/java/org/adaway/ui/welcome/WelcomeMethodFragment.java
+++ b/app/src/main/java/org/adaway/ui/welcome/WelcomeMethodFragment.java
@@ -1,6 +1,7 @@
 package org.adaway.ui.welcome;
 
 import static android.app.Activity.RESULT_OK;
+import static android.provider.Settings.ACTION_VPN_SETTINGS;
 import static org.adaway.model.adblocking.AdBlockMethod.ROOT;
 import static org.adaway.model.adblocking.AdBlockMethod.UNDEFINED;
 import static org.adaway.model.adblocking.AdBlockMethod.VPN;
@@ -10,6 +11,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.VpnService;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -50,6 +52,7 @@ public class WelcomeMethodFragment extends WelcomeFragment {
                 notifyVpnEnabled();
             } else {
                 notifyVpnDisabled();
+                checkAlwaysOnVPN();
             }
         });
 
@@ -122,5 +125,30 @@ public class WelcomeMethodFragment extends WelcomeFragment {
         this.binding.rootCardView.setCardBackgroundColor(this.cardColor);
         this.binding.vpnCardView.setCardBackgroundColor(this.cardColor);
         blockNext();
+    }
+
+    private void checkAlwaysOnVPN() {
+        int alwayson_message = R.string.welcome_vpn_alwayson_description;
+        try {
+            String alwaysOn = Settings.Secure.getString(getContext().getContentResolver(), "always_on_vpn_app");
+            if (alwaysOn == null)
+                return;
+        } catch (java.lang.SecurityException exception) {
+            // Some Android versions will block the always_on_vpn_app request, as it's not marked @Readable
+            alwayson_message = R.string.welcome_vpn_alwayson_blocked_description;
+        }
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.welcome_vpn_alwayson_title)
+                .setMessage(alwayson_message)
+                .setNegativeButton(R.string.button_close, null)
+                .setPositiveButton(
+                        R.string.welcome_vpn_alwayson_settings_action,
+                        (dialog, which) -> {
+                            dialog.dismiss();
+                            Intent intent = new Intent(ACTION_VPN_SETTINGS);
+                            startActivity(intent);
+                        })
+                .create()
+                .show();
     }
 }

--- a/app/src/main/res/values/strings_welcome.xml
+++ b/app/src/main/res/values/strings_welcome.xml
@@ -24,6 +24,11 @@
     <string name="welcome_root_missing_title">Rooted Android required</string>
     <string name="welcome_root_missile_description">Either the su binary could not be found or you did not allow root permission for AdAway.\n\nThis can happen when your device is not rooted. You can find information about how to root your device on wiki.lineageos.org or other Android websites.</string>
 
+    <string name="welcome_vpn_alwayson_title">Always-on VPN enabled</string>
+    <string name="welcome_vpn_alwayson_description">AdAway detected that another VPN has the "Always-on VPN" setting active.\n\nThis prevents AdAway from requesting VPN access. Please disable "Always-on VPN" on the correspondent VPN and try again.</string>
+    <string name="welcome_vpn_alwayson_blocked_description">AdAway failed to request VPN access.\n\nThis might be caused because another VPN has the "Always-on VPN" setting active. Please, check if any VPN has this setting enabled and disable it before trying again.</string>
+    <string name="welcome_vpn_alwayson_settings_action">Open "VPN" Settings</string>
+
     <string name="welcome_method_pro_logo">Pro</string>
     <string name="welcome_method_con_logo">Con</string>
 


### PR DESCRIPTION
If another VPN is installed and has the "Always-on VPN" setting activated, it will cause the `VpnService` to fail with `RESULT_CANCELED`.
This means that when this is the case, the "VPN based ad blocking" button on the welcome activity will trigger `enableVpnService` which will fail silently, leaving the user clueless as to why.
This might be the cause of #2828.

This commit adds a check to see if a VPN has "Always-on VPN" enabled, and if so will warn the user that it needs to be disabled in order to set up AdAway.