### PR TITLE
Update AdwareLiveData.java : Fix potential NullPointerException in createInstallFromPackageInfo

### DIFF
--- a/app/src/main/java/org/adaway/ui/adware/AdwareLiveData.java
+++ b/app/src/main/java/org/adaway/ui/adware/AdwareLiveData.java
@@ -147,7 +147,8 @@ class AdwareLiveData extends LiveData<List<AdwareInstall>> {
         // Get the package manager
         PackageManager pm = this.context.getPackageManager();
         // Retrieve application name
-        String applicationName = pm.getApplicationLabel(packageInfo.applicationInfo).toString();
+        //String applicationName = pm.getApplicationLabel(packageInfo.applicationInfo).toString();
+        String applicationName = packageInfo.applicationInfo != null ? pm.getApplicationLabel(packageInfo.applicationInfo).toString() : "Unknown";
         // Add adware install
         return new AdwareInstall(applicationName, packageInfo.packageName);
     }


### PR DESCRIPTION
Prevent a possible NullPointerException in createInstallFromPackageInfo by adding a null check for packageInfo.applicationInfo. If applicationInfo is null, we now return a default application name ("Unknown") instead of calling getApplicationLabel, which would otherwise throw an exception. This improves the stability of the app and prevents crashes due to unexpected null values in PackageInfo.