### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/tcpdump/jni/tcpdump/print-frag6.c
+++ b/tcpdump/jni/tcpdump/print-frag6.c
@@ -41,7 +41,7 @@ frag6_print(netdissect_options *ndo, register const u_char *bp, register const u
 	dp = (const struct ip6_frag *)bp;
 	ip6 = (const struct ip6_hdr *)bp2;
 
-	ND_TCHECK(dp->ip6f_offlg);
+	ND_TCHECK(*dp);
 
 	if (ndo->ndo_vflag) {
 		ND_PRINT((ndo, "frag (0x%08x:%d|%ld)",


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in frag6_print() that was cloned from tcpdump but did not receive the security patch. The original issue was reported and fixed under https://github.com/the-tcpdump-group/tcpdump/commit/2d669862df7cd17f539129049f6fb70d17174125.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2017-13031
https://github.com/the-tcpdump-group/tcpdump/commit/2d669862df7cd17f539129049f6fb70d17174125
