### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -247,7 +247,7 @@
 
     <!--VPN notification-->
     <string name="vpn_notification_starting">A começar</string>
-    <string name="vpn_notification_running">Ativo</string>
+    <string name="vpn_notification_running">Ativa</string>
     <string name="vpn_notification_stopping">a parar</string>
     <string name="vpn_notification_waiting_for_net">espere por internet</string>
     <string name="vpn_notification_reconnecting">a reconnectar</string>


### PR DESCRIPTION
I tried this app and noticed some translation errors, especially in a message that seems to be always displayed while using it: "Vpn bloqueadora de anúnciosAtivo." The acronym "VPN" should be kept uppercase as "VPN" rather than "Vpn." Additionally, there should be a space before "Ativo." Finally, since the word "VPN" is feminine in Portuguese, just like the adjective "bloqueadora," it should be "Ativa" instead of "Ativo."

While I have not thoroughly reviewed all translated files, I did fix a few more similar mistakes in this file.

I hope this feedback is helpful.