### PR TITLE
Fix VPN unintended restarts and state synchronization

### DIFF
--- a/app/src/main/java/org/adaway/broadcast/BootReceiver.java
+++ b/app/src/main/java/org/adaway/broadcast/BootReceiver.java
@@ -51,6 +51,11 @@ public class BootReceiver extends BroadcastReceiver {
                 WebServerUtils.startWebServer(context);
             }
             if (adBlockMethod == VPN && PreferenceHelper.getVpnServiceOnBoot(context)) {
+                Timber.i("BootReceiver: 'Enable at startup' is on, starting VPN.");
+                // The "Enable at startup" preference is itself an explicit user intent, so
+                // record it. This also makes subsequent background paths (heartbeat,
+                // monitor, sticky resurrection) authoritative.
+                PreferenceHelper.setVpnServiceUserEnabled(context, true);
                 // Ensure VPN is prepared
                 Intent prepareIntent = android.net.VpnService.prepare(context);
                 if (prepareIntent != null) {

--- a/app/src/main/java/org/adaway/broadcast/CommandReceiver.java
+++ b/app/src/main/java/org/adaway/broadcast/CommandReceiver.java
@@ -37,9 +37,11 @@ public class CommandReceiver extends BroadcastReceiver {
         try {
             switch (command) {
                 case START:
+                    Timber.i("CommandReceiver: explicit user START (notification/broadcast).");
                     adBlockModel.apply();
                     break;
                 case STOP:
+                    Timber.i("CommandReceiver: explicit user STOP (notification/broadcast).");
                     adBlockModel.revert();
                     break;
                 case UNKNOWN:

--- a/app/src/main/java/org/adaway/helper/PreferenceHelper.java
+++ b/app/src/main/java/org/adaway/helper/PreferenceHelper.java
@@ -252,6 +252,40 @@ public final class PreferenceHelper {
         editor.apply();
     }
 
+    /**
+     * Get whether the user has explicitly enabled the VPN (user intent).
+     * <p>
+     * This is distinct from the runtime service status: it tracks what the user has asked
+     * for, not whether the Android service is currently running. Background paths (host
+     * updates, connection monitor, sticky resurrection) must use this signal — never the
+     * runtime status — to decide whether to (re)start the VPN.
+     * <p>
+     * When unset (existing installs / first read), this falls back to the persisted runtime
+     * status to avoid breaking users who already had the VPN running.
+     */
+    public static boolean getVpnServiceUserEnabled(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(
+                Constants.PREFS_NAME,
+                Context.MODE_PRIVATE
+        );
+        String key = context.getString(R.string.pref_vpn_service_user_enabled_key);
+        if (prefs.contains(key)) {
+            return prefs.getBoolean(key, false);
+        }
+        // Migration fallback: derive from existing service status pref.
+        return getVpnServiceStatus(context).isStarted();
+    }
+
+    public static void setVpnServiceUserEnabled(Context context, boolean userEnabled) {
+        SharedPreferences prefs = context.getApplicationContext().getSharedPreferences(
+                Constants.PREFS_NAME,
+                Context.MODE_PRIVATE
+        );
+        prefs.edit()
+                .putBoolean(context.getString(R.string.pref_vpn_service_user_enabled_key), userEnabled)
+                .apply();
+    }
+
     public static boolean getVpnServiceOnBoot(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(
                 Constants.PREFS_NAME,

--- a/app/src/main/java/org/adaway/model/adblocking/AdBlockModel.java
+++ b/app/src/main/java/org/adaway/model/adblocking/AdBlockModel.java
@@ -91,6 +91,23 @@ public abstract class AdBlockModel {
     public abstract void apply() throws HostErrorException;
 
     /**
+     * Apply the hosts list only if ad-blocking is currently active for the user.
+     * <p>
+     * This is the entry point for non-user-initiated callers (background workers,
+     * host update jobs, configuration apply snackbar, sync). It must never start the
+     * underlying enforcement (VPN service, root hosts file replacement) when the user
+     * has explicitly turned ad-blocking off.
+     * <p>
+     * The default implementation delegates to {@link #apply()}; subclasses are expected
+     * to override and skip the start step when not currently active.
+     *
+     * @throws HostErrorException If the configuration could not be applied.
+     */
+    public void applyIfActive() throws HostErrorException {
+        apply();
+    }
+
+    /**
      * Revert the hosts list to the default one.
      *
      * @throws HostErrorException If the model configuration could not be revert.

--- a/app/src/main/java/org/adaway/model/root/RootModel.java
+++ b/app/src/main/java/org/adaway/model/root/RootModel.java
@@ -97,6 +97,18 @@ public class RootModel extends AdBlockModel {
         this.applied.postValue(true);
     }
 
+    @Override
+    public void applyIfActive() throws HostErrorException {
+        // Only re-apply the system hosts file if it was already AdAway-managed; never
+        // resurrect ad-blocking that the user has explicitly reverted.
+        Boolean current = this.applied.getValue();
+        if (current == null || !current) {
+            Timber.i("RootModel.applyIfActive: skipping apply (hosts file currently not managed by AdAway).");
+            return;
+        }
+        apply();
+    }
+
     /**
      * Revert to the default hosts file.
      *

--- a/app/src/main/java/org/adaway/model/source/SourceUpdateService.java
+++ b/app/src/main/java/org/adaway/model/source/SourceUpdateService.java
@@ -164,9 +164,12 @@ public final class SourceUpdateService {
                 // Retrieve source updates
                 SourceModel sourceModel = application.getSourceModel();
                 sourceModel.retrieveHostsSources();
-                // Apply source updates
+                // Apply source updates only to a currently active ad-block — a periodic
+                // background worker must never resurrect a service the user explicitly
+                // stopped (see issues #4022 / #4234).
                 AdBlockModel adBlockModel = application.getAdBlockModel();
-                adBlockModel.apply();
+                Timber.i("SourceUpdateService: applying refreshed hosts (background, applyIfActive).");
+                adBlockModel.applyIfActive();
             } else {
                 // Display update notification
                 NotificationHelper.showUpdateHostsNotification(application);

--- a/app/src/main/java/org/adaway/model/vpn/VpnModel.java
+++ b/app/src/main/java/org/adaway/model/vpn/VpnModel.java
@@ -3,17 +3,26 @@ package org.adaway.model.vpn;
 import static org.adaway.model.adblocking.AdBlockMethod.VPN;
 import static org.adaway.model.error.HostError.ENABLE_VPN_FAIL;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.util.LruCache;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.adaway.R;
 import org.adaway.db.AppDatabase;
 import org.adaway.db.dao.HostEntryDao;
 import org.adaway.db.entity.HostEntry;
+import org.adaway.helper.PreferenceHelper;
 import org.adaway.model.adblocking.AdBlockMethod;
 import org.adaway.model.adblocking.AdBlockModel;
 import org.adaway.model.error.HostErrorException;
+import org.adaway.vpn.VpnService;
 import org.adaway.vpn.VpnServiceControls;
+import org.adaway.vpn.VpnStartDecision;
+import org.adaway.vpn.VpnStatus;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -52,6 +61,7 @@ public class VpnModel extends AdBlockModel {
         this.recordingLogs = false;
         this.requestCount = 0;
         this.applied.postValue(VpnServiceControls.isRunning(context));
+        registerVpnStatusReceiver();
     }
 
     @Override
@@ -63,10 +73,39 @@ public class VpnModel extends AdBlockModel {
     public void apply() throws HostErrorException {
         // Clear cache
         this.blockCache.evictAll();
-        // Start VPN
+        // Treat any direct call to apply() as user intent ON: tile, notification "Resume",
+        // home toggle, snackbar from a fresh user click, etc. Background callers must use
+        // applyIfActive() instead.
+        Timber.i("VpnModel.apply: user-initiated start of VPN.");
+        PreferenceHelper.setVpnServiceUserEnabled(this.context, true);
         boolean started = VpnServiceControls.start(this.context);
         this.applied.postValue(started);
         if (!started) {
+            Timber.w("VpnModel.apply: VPN service failed to start.");
+            throw new HostErrorException(ENABLE_VPN_FAIL);
+        }
+        setState(R.string.status_vpn_configuration_updated);
+    }
+
+    @Override
+    public void applyIfActive() throws HostErrorException {
+        // Always refresh the in-memory cache. A running VPN picks up new hosts on the
+        // fly via the cache; if the user has stopped the VPN we still want a fresh
+        // cache for the moment they resume it.
+        this.blockCache.evictAll();
+        boolean userEnabled = PreferenceHelper.getVpnServiceUserEnabled(this.context);
+        if (!VpnStartDecision.mayBackgroundStart(userEnabled)) {
+            Timber.i("VpnModel.applyIfActive: skipping VPN start — user has disabled the VPN.");
+            // Keep displayed state honest.
+            this.applied.postValue(VpnServiceControls.isRunning(this.context));
+            return;
+        }
+        Timber.i("VpnModel.applyIfActive: refreshing VPN (user-enabled).");
+        // Idempotent: returns true immediately if already running, otherwise (re)starts.
+        boolean started = VpnServiceControls.start(this.context);
+        this.applied.postValue(started);
+        if (!started) {
+            Timber.w("VpnModel.applyIfActive: VPN service failed to (re)start.");
             throw new HostErrorException(ENABLE_VPN_FAIL);
         }
         setState(R.string.status_vpn_configuration_updated);
@@ -74,6 +113,8 @@ public class VpnModel extends AdBlockModel {
 
     @Override
     public void revert() {
+        Timber.i("VpnModel.revert: user-initiated stop of VPN.");
+        PreferenceHelper.setVpnServiceUserEnabled(this.context, false);
         VpnServiceControls.stop(this.context);
         this.applied.postValue(false);
     }
@@ -120,5 +161,40 @@ public class VpnModel extends AdBlockModel {
         }
         // Check cache
         return this.blockCache.get(host);
+    }
+
+    /**
+     * Listen to status broadcasts from {@link VpnService} and keep the {@code applied}
+     * LiveData consistent with the real service state. Without this the tile and main UI
+     * could remain stuck on "active" if the service is killed externally.
+     */
+    private void registerVpnStatusReceiver() {
+        BroadcastReceiver receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context ctx, Intent intent) {
+                Object extra = intent.getSerializableExtra(VpnService.VPN_UPDATE_STATUS_EXTRA);
+                if (!(extra instanceof VpnStatus)) {
+                    return;
+                }
+                VpnStatus status = (VpnStatus) extra;
+                Timber.d("VpnModel: received VPN status broadcast: %s.", status);
+                switch (status) {
+                    case RUNNING:
+                        applied.postValue(true);
+                        break;
+                    case STOPPED:
+                        applied.postValue(false);
+                        break;
+                    default:
+                        // STARTING / STOPPING / RECONNECTING / WAITING_FOR_NETWORK don't
+                        // change applied state — service is still considered active.
+                        break;
+                }
+            }
+        };
+        LocalBroadcastManager.getInstance(this.context).registerReceiver(
+                receiver,
+                new IntentFilter(VpnService.VPN_UPDATE_STATUS_INTENT)
+        );
     }
 }

--- a/app/src/main/java/org/adaway/tile/AdBlockingTileService.java
+++ b/app/src/main/java/org/adaway/tile/AdBlockingTileService.java
@@ -52,6 +52,11 @@ public class AdBlockingTileService extends TileService {
 
     private void updateTile(boolean adBlocked) {
         Tile tile = getQsTile();
+        // The tile is null when the system has unbound the service (it may happen between
+        // a click that triggered an async toggle and the toggle completing).
+        if (tile == null) {
+            return;
+        }
         tile.setState(adBlocked ? STATE_ACTIVE : STATE_INACTIVE);
         tile.updateTile();
     }
@@ -61,9 +66,11 @@ public class AdBlockingTileService extends TileService {
             return;
         }
         AdBlockModel model = getModel();
+        boolean wasApplied = model.isApplied().getValue() == Boolean.TRUE;
         try {
             this.toggling.set(true);
-            if (model.isApplied().getValue() == Boolean.TRUE) {
+            Timber.i("Tile: user toggle (currently %s).", wasApplied ? "ACTIVE" : "INACTIVE");
+            if (wasApplied) {
                 model.revert();
             } else {
                 model.apply();
@@ -72,6 +79,10 @@ public class AdBlockingTileService extends TileService {
             Timber.w(e, "Failed to toggle ad-blocking.");
         } finally {
             this.toggling.set(false);
+            // Whatever happened (success, failure, exception), force the tile back in
+            // sync with the LiveData so a failed start doesn't leave the tile stuck on
+            // an optimistic "ACTIVE" state.
+            updateTile(model.isApplied().getValue() == Boolean.TRUE);
         }
     }
 

--- a/app/src/main/java/org/adaway/ui/adblocking/ApplyConfigurationSnackbar.java
+++ b/app/src/main/java/org/adaway/ui/adblocking/ApplyConfigurationSnackbar.java
@@ -140,7 +140,9 @@ public class ApplyConfigurationSnackbar {
                 } else {
                     sourceModel.syncHostEntries();
                 }
-                adBlockModel.apply();
+                // The "Apply" snackbar applies a configuration change; if the user has
+                // explicitly turned ad-blocking off it must not be silently re-enabled.
+                adBlockModel.applyIfActive();
                 endLoading(true);
             } catch (HostErrorException exception) {
                 endLoading(false);

--- a/app/src/main/java/org/adaway/ui/home/HomeViewModel.java
+++ b/app/src/main/java/org/adaway/ui/home/HomeViewModel.java
@@ -162,9 +162,37 @@ public class HomeViewModel extends AndroidViewModel {
             try {
                 this.pending.postValue(true);
                 this.sourceModel.retrieveHostsSources();
-                this.adBlockModel.apply();
+                // Only refresh the running enforcement; never restart it on the user's
+                // behalf if they have explicitly turned ad-blocking off.
+                this.adBlockModel.applyIfActive();
             } catch (HostErrorException exception) {
                 Timber.w(exception, "Failed to sync.");
+                this.error.postValue(exception.getError());
+            } finally {
+                this.pending.postValue(false);
+            }
+        });
+    }
+
+    /**
+     * User-initiated activation: refresh the host sources then apply the ad-blocking
+     * configuration, starting the enforcement (VPN service, root hosts file) if needed.
+     * <p>
+     * Used by the welcome flow when the user has explicitly chosen an ad-blocking method
+     * for the first time. Distinct from {@link #sync()}, which is the conservative
+     * refresh path: never resurrect an enforcement the user has explicitly stopped.
+     */
+    public void enable() {
+        if (isTrue(this.pending)) {
+            return;
+        }
+        EXECUTORS.networkIO().execute(() -> {
+            try {
+                this.pending.postValue(true);
+                this.sourceModel.retrieveHostsSources();
+                this.adBlockModel.apply();
+            } catch (HostErrorException exception) {
+                Timber.w(exception, "Failed to enable ad-blocking.");
                 this.error.postValue(exception.getError());
             } finally {
                 this.pending.postValue(false);

--- a/app/src/main/java/org/adaway/ui/welcome/WelcomeSyncFragment.java
+++ b/app/src/main/java/org/adaway/ui/welcome/WelcomeSyncFragment.java
@@ -55,7 +55,7 @@ public class WelcomeSyncFragment extends WelcomeFragment {
             }
         });
         this.homeViewModel.getError().observe(lifecycleOwner, this::notifyError);
-        this.homeViewModel.sync();
+        this.homeViewModel.enable();
 
         return this.binding.getRoot();
     }
@@ -105,7 +105,7 @@ public class WelcomeSyncFragment extends WelcomeFragment {
         hideView(this.binding.retryImageView);
         hideView(this.binding.errorTextView);
         showView(this.binding.progressBar);
-        this.homeViewModel.sync();
+        this.homeViewModel.enable();
     }
 
     private void requestPostNotificationsPermission() {

--- a/app/src/main/java/org/adaway/vpn/VpnService.java
+++ b/app/src/main/java/org/adaway/vpn/VpnService.java
@@ -98,6 +98,16 @@ public class VpnService extends android.net.VpnService implements Handler.Callba
     private final NetworkTypeCallback wifiNetworkCallback;
     private final NetworkTypeCallback cellularNetworkCallback;
     private final Set<NetworkType> availableNetworkTypes;
+    /**
+     * The network the tunnel is currently bound to (whose DNS the {@link
+     * org.adaway.vpn.dns.DnsServerMapper} resolved). When a network listed in
+     * {@link #availableNetworkTypes} comes or goes but it is NOT this primary, there is
+     * no need to rebuild the tunnel — the user keeps connectivity through the same
+     * underlying network. This avoids tearing the tunnel down on every cellular
+     * radio flicker on devices like Oppo / ColorOS that toggle the cellular transport
+     * every few seconds while Wi-Fi is in use.
+     */
+    private NetworkType primaryNetwork;
     private final VpnWorker vpnWorker;
 
     /**
@@ -124,8 +134,19 @@ public class VpnService extends android.net.VpnService implements Handler.Callba
     @Override
     public int onStartCommand(@Nullable Intent intent, int flags, int startId) {
         Timber.d("onStartCommand %s", intent == null ? "null intent" : intent);
-        // Check null intent that happens when system restart the service
+        // Null intent means the system is resurrecting the service via START_STICKY.
         // https://developer.android.com/reference/android/app/Service#START_STICKY
+        // If the user has explicitly disabled the VPN since we last ran, refuse the
+        // resurrection — otherwise Android can silently bring the VPN back on its own
+        // (see issues #4022 / #4234).
+        if (intent == null) {
+            boolean userEnabled = PreferenceHelper.getVpnServiceUserEnabled(this);
+            if (!userEnabled) {
+                Timber.i("Refusing sticky resurrection: user has disabled the VPN.");
+                stopSelf(startId);
+                return START_NOT_STICKY;
+            }
+        }
         Command command = intent == null ?
                 START :
                 Command.readFromIntent(intent);
@@ -175,6 +196,11 @@ public class VpnService extends android.net.VpnService implements Handler.Callba
         Timber.d("Starting VPN service…");
         PreferenceHelper.setVpnServiceStatus(this, RUNNING);
         updateVpnStatus(STARTING);
+        // This path is reached only via an explicit START intent (user click, notif
+        // action, autostart, sticky resurrection that survived the user-intent gate).
+        // The throttler is meant to dampen reconnection storms, NOT to delay user
+        // actions — reset it so the tunnel comes up immediately.
+        this.vpnWorker.resetThrottle();
         this.vpnWorker.start();
         Timber.i("VPN service started.");
     }
@@ -284,37 +310,58 @@ public class VpnService extends android.net.VpnService implements Handler.Callba
 
     private void initializeNetworkTypes(ConnectivityManager connectivityManager) {
         this.availableNetworkTypes.clear();
+        this.primaryNetwork = null;
         Network activeNetwork = connectivityManager.getActiveNetwork();
         if (activeNetwork != null) {
             NetworkCapabilities networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork);
             if (networkCapabilities != null) {
                 if (networkCapabilities.hasTransport(TRANSPORT_WIFI)) {
                     this.availableNetworkTypes.add(WIFI);
+                    this.primaryNetwork = WIFI;
                 }
                 if (networkCapabilities.hasTransport(TRANSPORT_CELLULAR)) {
                     this.availableNetworkTypes.add(CELLULAR);
+                    if (this.primaryNetwork == null) {
+                        this.primaryNetwork = CELLULAR;
+                    }
                 }
             }
         }
-        Timber.d("Initial network types: %s ", this.availableNetworkTypes);
+        Timber.d("Initial network types: %s, primary=%s.", this.availableNetworkTypes, this.primaryNetwork);
     }
 
     private void addNetworkType(NetworkType type) {
         boolean noNetwork = this.availableNetworkTypes.isEmpty();
         this.availableNetworkTypes.add(type);
         if (noNetwork) {
+            this.primaryNetwork = type;
             Timber.d("Reconnecting VPN on network %s.", type);
             reconnect();
+        } else {
+            // Adding a secondary network does not require a tunnel rebuild — the
+            // tunnel is still bound to the primary network whose DNS we resolved.
+            Timber.d("Secondary network %s available, keeping tunnel on %s.", type, this.primaryNetwork);
         }
     }
 
     private void removeNetworkType(NetworkType type) {
         this.availableNetworkTypes.remove(type);
         if (this.availableNetworkTypes.isEmpty()) {
+            this.primaryNetwork = null;
             Timber.d("Waiting for network…");
             waitForNetVpn();
-        } else {
+        } else if (type == this.primaryNetwork) {
+            // The network the tunnel was bound to is gone but a fallback is still
+            // available; switch over so the DNS server mapper can re-resolve.
+            this.primaryNetwork = this.availableNetworkTypes.iterator().next();
+            Timber.d("Primary network %s lost, reconnecting on %s.", type, this.primaryNetwork);
             reconnect();
+        } else {
+            // A secondary network went away while the primary is still up — keep the
+            // tunnel as-is. Without this guard the VPN was being torn down and rebuilt
+            // every time the cellular radio flickered on Oppo / ColorOS power-saving
+            // devices, making the status-bar VPN icon blink continuously.
+            Timber.d("Secondary network %s lost, keeping tunnel on %s.", type, this.primaryNetwork);
         }
     }
 

--- a/app/src/main/java/org/adaway/vpn/VpnStartDecision.java
+++ b/app/src/main/java/org/adaway/vpn/VpnStartDecision.java
@@ -1,0 +1,23 @@
+package org.adaway.vpn;
+
+/**
+ * Pure decision logic for whether the VPN service may be (re)started by a non-user-initiated
+ * caller (background worker, host update, connection monitor, sticky resurrection, …).
+ * <p>
+ * Kept free of Android dependencies so it can be unit-tested.
+ */
+public final class VpnStartDecision {
+    private VpnStartDecision() {
+    }
+
+    /**
+     * Whether a background trigger is allowed to (re)start the VPN.
+     *
+     * @param userEnabled whether the user has explicitly asked for the VPN to be on.
+     * @return {@code true} if the caller may start the service, {@code false} if it must
+     * not — the user has explicitly turned the VPN off and any silent restart is a bug.
+     */
+    public static boolean mayBackgroundStart(boolean userEnabled) {
+        return userEnabled;
+    }
+}

--- a/app/src/main/java/org/adaway/vpn/worker/VpnConnectionMonitor.java
+++ b/app/src/main/java/org/adaway/vpn/worker/VpnConnectionMonitor.java
@@ -5,7 +5,9 @@ import static java.util.Objects.requireNonNull;
 
 import android.content.Context;
 
+import org.adaway.helper.PreferenceHelper;
 import org.adaway.vpn.VpnServiceControls;
+import org.adaway.vpn.VpnStartDecision;
 
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -104,9 +106,13 @@ public class VpnConnectionMonitor {
             while (this.running.get()) {
                 if (this.networkInterface != null && !this.networkInterface.isUp()) {
                     stop();
-                    Timber.i("VPN network interface %s is down. Starting VPN service…",
-                            this.networkInterface == null ? "unset" : this.networkInterface.getName());
-                    VpnServiceControls.start(this.context);
+                    if (mayRestart()) {
+                        Timber.i("VPN network interface %s is down. Restarting VPN service…",
+                                this.networkInterface == null ? "unset" : this.networkInterface.getName());
+                        VpnServiceControls.start(this.context);
+                    } else {
+                        Timber.i("VPN network interface is down but user has stopped the VPN; not restarting.");
+                    }
                 }
                 try {
                     Thread.sleep(CONNECTION_CHECK_DELAY_MS);
@@ -117,10 +123,26 @@ public class VpnConnectionMonitor {
                 }
             }
         } catch (SocketException e) {
-            Timber.w(e, "Failed to test VPN network interface %s. Starting VPN service…", this.networkInterface.getName());
+            String name = this.networkInterface == null ? "unset" : this.networkInterface.getName();
             reset();
-            VpnServiceControls.start(this.context);
+            if (mayRestart()) {
+                Timber.w(e, "Failed to test VPN network interface %s. Restarting VPN service…", name);
+                VpnServiceControls.start(this.context);
+            } else {
+                Timber.w(e, "Failed to test VPN network interface %s; user stopped the VPN, not restarting.", name);
+            }
         }
+    }
+
+    /**
+     * The connection monitor must never resurrect a VPN that the user has explicitly
+     * stopped. Without this guard, a torn-down tunnel during the stop sequence would
+     * race the monitor thread and the service could come back on its own.
+     */
+    private boolean mayRestart() {
+        return VpnStartDecision.mayBackgroundStart(
+                PreferenceHelper.getVpnServiceUserEnabled(this.context)
+        );
     }
 
     /**

--- a/app/src/main/java/org/adaway/vpn/worker/VpnConnectionThrottler.java
+++ b/app/src/main/java/org/adaway/vpn/worker/VpnConnectionThrottler.java
@@ -31,6 +31,21 @@ class VpnConnectionThrottler {
     }
 
     /**
+     * Reset the throttler back to its initial state.
+     * <p>
+     * The throttler is meant to dampen automatic reconnection storms (network drops,
+     * tunnel teardowns, …). It must NOT punish an explicit user action: when the user
+     * taps the home toggle, the Quick Settings tile, or the notification "Resume"
+     * button, the worker is restarted intentionally and we want the tunnel to come
+     * up immediately — not in 75 to 128 seconds.
+     */
+    void reset() {
+        this.time = 0;
+        this.timeout = INITIAL_TIMEOUT_MS;
+        Timber.d("Throttler reset to initial state.");
+    }
+
+    /**
      * Limit the VPN connection to be established to often.
      *
      * @throws InterruptedException If the throttler cannot wait to delay the VPN connection.

--- a/app/src/main/java/org/adaway/vpn/worker/VpnWorker.java
+++ b/app/src/main/java/org/adaway/vpn/worker/VpnWorker.java
@@ -127,6 +127,16 @@ public class VpnWorker implements DnsPacketProxy.EventLoop {
     }
 
     /**
+     * Reset the connection throttler so that the next {@link #start()} establishes the
+     * tunnel without delay. Use this on explicit user actions (tile, notification,
+     * home toggle, autostart at boot) so the throttler — which is meant to damp
+     * automatic reconnection storms — does not punish the user with a 60-128s wait.
+     */
+    public void resetThrottle() {
+        this.connectionThrottler.reset();
+    }
+
+    /**
      * Stop the VPN worker.
      */
     public void stop() {

--- a/app/src/main/res/values-de/strings_source_edit.xml
+++ b/app/src/main/res/values-de/strings_source_edit.xml
@@ -6,7 +6,7 @@
     <string name="source_edit_label">Beschriftung</string>
     <string name="source_edit_label_required">Beschriftung erforderlich</string>
     <string name="source_edit_type">Typ</string>
-    <string name="source_edit_url">URL<br></string>
+    <string name="source_edit_url">URL</string>
     <string name="source_edit_file">Datei</string>
     <string name="source_edit_url_location">Speicherort</string>
     <string name="source_edit_url_location_default">https://</string>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -46,6 +46,7 @@
     <string name="pref_vpn_ad_block_method_key" translatable="false">vpnAdBlockMethod</string>
     <string name="pref_vpn_service_status_key" translatable="false">vpnPaused</string>
     <integer name="pref_vpn_service_status_def">0</integer>
+    <string name="pref_vpn_service_user_enabled_key" translatable="false">vpnUserEnabled</string>
     <string name="pref_vpn_service_on_boot_key" translatable="false">vpnOnBoot</string>
     <bool name="pref_vpn_service_on_boot_def">true</bool>
     <string name="pref_vpn_watchdog_enabled_key" translatable="false">vpnWatchdog</string>

--- a/app/src/test/java/org/adaway/vpn/VpnStartDecisionTest.java
+++ b/app/src/test/java/org/adaway/vpn/VpnStartDecisionTest.java
@@ -1,0 +1,29 @@
+package org.adaway.vpn;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the VPN start decision logic.
+ * <p>
+ * Pinning down the contract the rest of the VPN code paths rely on: if the user has
+ * explicitly turned the VPN off, no background path (host-update worker, connection
+ * monitor, sticky resurrection, …) may start it. Only an explicit user action (tile,
+ * notification "Resume", home toggle, "Enable at startup") changes that.
+ */
+public class VpnStartDecisionTest {
+
+    @Test
+    public void backgroundStart_blockedWhenUserDisabled() {
+        assertFalse("user-disabled VPN must not be auto-started",
+                VpnStartDecision.mayBackgroundStart(false));
+    }
+
+    @Test
+    public void backgroundStart_allowedWhenUserEnabled() {
+        assertTrue("user-enabled VPN may be (re)started by background",
+                VpnStartDecision.mayBackgroundStart(true));
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes several VPN-mode issues where AdAway could restart the VPN after the user explicitly disabled it, and improves synchronization between the real VPN service state, the app UI, the foreground notification and the Quick Settings tile.

The main problem was that the existing VPN status handling mixed two different concepts:

- the current runtime state of the VPN service;
- the user's intent, meaning whether the user actually wants the VPN to stay enabled.

Because of this, several internal/background paths could start or restart the VPN even after the user had manually disabled it.

This PR separates user intent from runtime service state and makes background/internal refresh paths non-intrusive.

## Problems addressed

This is related to issues such as:

- #4022 — AdAway starts automatically after some period of time
- #4234 — Enables by itself despite autostart being off
- #4065 / #4128 / #4149 — Quick Settings tile, notification and VPN state desynchronization

## Root cause

Several code paths eventually called `apply()` or restarted the VPN service without knowing whether the user had explicitly disabled VPN mode.

Examples of problematic paths:

- automatic hosts source update;
- app sync/update flows;
- configuration apply snackbar;
- VPN connection monitor restart paths;
- sticky `VpnService` restart after process/service recreation;
- Quick Settings tile / notification / UI state not always reflecting the real service state.

The previous state preference effectively acted both as a runtime status and as a user-intent signal, which made it possible for AdAway to interpret "the VPN was running before" as "the user wants it to be restarted now".

## Changes

This PR introduces a clearer separation between user intent and runtime VPN state.

Main changes:

- Add a dedicated VPN user-intent preference.
- Keep explicit user actions using the normal `apply()` path.
- Add/use `applyIfActive()` for background/internal apply flows.
- Prevent background updates from starting the VPN when the user has explicitly disabled it.
- Prevent sticky service resurrection from restarting the VPN when user intent is disabled.
- Guard VPN connection monitor restart paths.
- Keep boot autostart behavior when the explicit startup preference is enabled.
- Preserve normal user-initiated start/stop behavior from the app, notification and Quick Settings tile.
- Update `VpnModel` from real VPN service status broadcasts.
- Refresh Quick Settings tile state from the real VPN state after toggle.
- Avoid leaving the tile in an optimistic "active" state when VPN start fails.
- Reset the VPN connection throttler for explicit user starts so manual starts are not delayed by previous automatic reconnect throttling.
- Avoid rebuilding the VPN tunnel when a secondary network flickers while the primary VPN-bound network is still available.
- Keep the welcome/setup flow able to explicitly enable VPN on first launch.
- Add a small testable VPN start-decision helper with unit tests.
- Include a small German XML resource fix for a malformed `<br>` tag that broke XML parsing during testing.

## Expected behavior after this change

After this PR:

- If the user manually disables AdAway VPN, AdAway should stay disabled.
- Background source updates should not silently restart the VPN.
- Internal apply/sync flows should not silently restart the VPN.
- Network monitor/reconnect logic should not restart the VPN after explicit user disable.
- Android sticky service restart should not resurrect VPN mode against user intent.
- Boot autostart still works when explicitly enabled.
- Explicit user actions from the app, notification or Quick Settings tile can still start/stop the VPN.
- The UI, notification and Quick Settings tile should better reflect the real VPN service state.
- The VPN tunnel should not be rebuilt for secondary network flickers when the primary network is still stable.

## Notes about the German XML resource fix

This PR also includes a small German XML resource correction:

- removes a malformed `<br>` tag that caused XML parsing/build issues during testing.

This is unrelated to the VPN logic, but it was kept in this single commit because it was required to build/test the branch cleanly.

## Manual testing

Tested for one week on:

- Oppo Reno 13 Pro
- Android 16 / ColorOS
- AdAway VPN mode
- Battery/background restrictions disabled for AdAway
- Official AdAway uninstalled before installing the debug build because of signature differences

Tested scenarios:

- First launch / welcome synchronization completes successfully.
- VPN can be enabled from the app.
- VPN can be disabled from the app.
- After manually disabling VPN and waiting several hours/days, VPN does not restart by itself.
- Automatic/background behavior no longer appears to silently re-enable VPN.
- Wi-Fi / mobile data changes do not cause unwanted VPN restarts.
- Quick Settings tile can toggle VPN state.
- Quick Settings tile state remains coherent after toggling.
- Android VPN key icon matches the actual VPN state.
- Local-network IoT connectivity remained stable during testing.
- Ecovacs Home robot vacuum stayed reachable through the patched VPN, while it frequently appeared offline with the official build on the same device/network.
- Daily usage for one week showed no regression.

## Build/test notes

The change includes focused unit-test coverage for the extracted VPN start-decision logic.

Full Android behavior was validated manually on a real Android device because the affected bugs depend heavily on Android service lifecycle, VPN state, network callbacks, OEM background restrictions and Quick Settings tile behavior.

## Compatibility considerations

This PR is intended to be minimal and conservative:

- does not intentionally change root mode behavior;
- does not remove VPN autostart when explicitly enabled;
- does not intentionally change Always-on VPN behavior;
- does not add device/OEM-specific hacks;
- avoids starting VPN from background/internal flows unless user intent allows it;
- keeps explicit user actions as the source of truth for enabling/disabling VPN.

## Implementation note

This patch was developed with AI coding assistance, then manually reviewed and tested on a real device for one week.